### PR TITLE
fix EOL and permissions on windows

### DIFF
--- a/R/dir.R
+++ b/R/dir.R
@@ -14,6 +14,8 @@ create_wf_dir <- function(wf_summary) {
 
   wf_tmpl_dir <- fs::path(get_templates_dir(), "workflow")
   fs::dir_copy(wf_tmpl_dir, wf_root)
+  start_workflow <- fs::path(wf_root, "start_workflow.sh")
+  fs::file_chmod(start_workflow, "+x")
 
   create_ctrl_script(wf_summary)
   write_wf_summary(wf_summary)

--- a/inst/templates/workflow/start_workflow.sh
+++ b/inst/templates/workflow/start_workflow.sh
@@ -29,6 +29,9 @@ then
   mkdir -p "$SWF_LOG_DIR"
 fi
 
+# change CRLF ending files to LF
+find "$SWF_ROOT" -type f | xargs file -F "::" | grep CRLF | sed 's/::.*$//' | xargs perl -pi -e 's/\r\n/\n/g'
+
 sbatch  --output="$SWF__CTRL_OUT" \
         --job-name="$SWF__CTRL_NAME" \
         "$SWF__CTRL_SCRIPT" "$FIRST_STEP"

--- a/tests/testthat/test-add_workflow_step.R
+++ b/tests/testthat/test-add_workflow_step.R
@@ -2,7 +2,7 @@ test_that("`add_workflow_step` produces the right file structure", {
   test_dir <- "workflows"
   withr::local_file(test_dir)
 
-  wf_name <- "test_wf"
+  wf_name <- "test_step_struct"
 
   wf <- create_workflow(
     wf_name = wf_name,

--- a/tests/testthat/test-create_workflow.R
+++ b/tests/testthat/test-create_workflow.R
@@ -2,7 +2,7 @@ test_that("`create_workflow` produces the right file structure", {
   test_dir <- "workflows"
   withr::local_file(test_dir)
 
-  wf_name <- "test_wf"
+  wf_name <- "test_wf_struct"
 
   wf <- create_workflow(
     wf_name = wf_name,
@@ -30,7 +30,7 @@ test_that("`create_workflow` fails if a workflow with the same name already exis
   test_dir <- "workflows"
   withr::local_file(test_dir)
 
-  wf_name <- "test_wf"
+  wf_name <- "test_wf_dupl"
 
   create_workflow(
     wf_name = wf_name,


### PR DESCRIPTION
- use `fs::chmod` to make start_workflow.sh executable
- modify start_workflow.sh to replace CRLF with LF before sbatch submission