### PR TITLE
replace `setup_script` with `setup_lines`

### DIFF
--- a/man/step_tmpl_do_call.Rd
+++ b/man/step_tmpl_do_call.Rd
@@ -4,7 +4,7 @@
 \alias{step_tmpl_do_call}
 \title{Step template to run an R function}
 \usage{
-step_tmpl_do_call(what, args, setup_script = NULL)
+step_tmpl_do_call(what, args, setup_lines = NULL)
 }
 \arguments{
 \item{what}{The R function to be run by the workflow step}
@@ -12,7 +12,7 @@ step_tmpl_do_call(what, args, setup_script = NULL)
 \item{args}{a \emph{list} of arguments to the function call. The \code{names}
 attribute of \code{args} gives the argument names.}
 
-\item{setup_script}{(optional) a bash script to be run first.
+\item{setup_lines}{(optional) a vector of bash lines to be run first.
 This can be used to load the required modules (like R, python, etc).}
 }
 \value{

--- a/man/step_tmpl_do_call_script.Rd
+++ b/man/step_tmpl_do_call_script.Rd
@@ -4,7 +4,7 @@
 \alias{step_tmpl_do_call_script}
 \title{Step template to run an R script with a set of arguments}
 \usage{
-step_tmpl_do_call_script(r_script, args = list(), setup_script = NULL)
+step_tmpl_do_call_script(r_script, args = list(), setup_lines = NULL)
 }
 \arguments{
 \item{r_script}{The R script to be run by the workflow step}
@@ -12,7 +12,7 @@ step_tmpl_do_call_script(r_script, args = list(), setup_script = NULL)
 \item{args}{a \emph{list} of arguments to the function call. The \code{names}
 attribute of \code{args} gives the argument names.}
 
-\item{setup_script}{(optional) a bash script to be run first.
+\item{setup_lines}{(optional) a vector of bash lines to be run first.
 This can be used to load the required modules (like R, python, etc).}
 }
 \value{

--- a/man/step_tmpl_map.Rd
+++ b/man/step_tmpl_map.Rd
@@ -8,7 +8,7 @@ step_tmpl_map(
   FUN,
   ...,
   MoreArgs = NULL,
-  setup_script = NULL,
+  setup_lines = NULL,
   max_array_size = Inf
 )
 }
@@ -21,7 +21,7 @@ positive length, or all of zero length).  See also ‘Details’.}
 \item{MoreArgs}{a \emph{list} of arguments to the function call. The \code{names}
 attribute of \code{args} gives the argument names.}
 
-\item{setup_script}{(optional) a bash script to be run first.
+\item{setup_lines}{(optional) a vector of bash lines to be run first.
 This can be used to load the required modules (like R, python, etc).}
 
 \item{max_array_size}{maximum number of array jobs to be submitted at the

--- a/man/step_tmpl_map_script.Rd
+++ b/man/step_tmpl_map_script.Rd
@@ -4,7 +4,7 @@
 \alias{step_tmpl_map_script}
 \title{Step template to run an R script with a set of arguments}
 \usage{
-step_tmpl_map_script(r_script, ..., MoreArgs = NULL, setup_script = NULL)
+step_tmpl_map_script(r_script, ..., MoreArgs = NULL, setup_lines = NULL)
 }
 \arguments{
 \item{r_script}{The R script to be run by the workflow step}
@@ -15,7 +15,7 @@ positive length, or all of zero length).  See also ‘Details’.}
 \item{MoreArgs}{a \emph{list} of arguments to the function call. The \code{names}
 attribute of \code{args} gives the argument names.}
 
-\item{setup_script}{(optional) a bash script to be run first.
+\item{setup_lines}{(optional) a vector of bash lines to be run first.
 This can be used to load the required modules (like R, python, etc).}
 }
 \value{

--- a/man/step_tmpl_renv_restore.Rd
+++ b/man/step_tmpl_renv_restore.Rd
@@ -4,10 +4,10 @@
 \alias{step_tmpl_renv_restore}
 \title{Step template to update a project \code{renv}}
 \usage{
-step_tmpl_renv_restore(setup_script = NULL)
+step_tmpl_renv_restore(setup_lines = NULL)
 }
 \arguments{
-\item{setup_script}{(optional) a bash script to be run first.
+\item{setup_lines}{(optional) a vector of bash lines to be run first.
 This can be used to load the required modules (like R, python, etc).}
 }
 \value{

--- a/man/step_tmpl_rscript.Rd
+++ b/man/step_tmpl_rscript.Rd
@@ -4,12 +4,12 @@
 \alias{step_tmpl_rscript}
 \title{Step template to run an R script}
 \usage{
-step_tmpl_rscript(r_script, setup_script = NULL)
+step_tmpl_rscript(r_script, setup_lines = NULL)
 }
 \arguments{
 \item{r_script}{The R script to be run by the workflow step}
 
-\item{setup_script}{(optional) a bash script to be run first.
+\item{setup_lines}{(optional) a vector of bash lines to be run first.
 This can be used to load the required modules (like R, python, etc).}
 }
 \value{


### PR DESCRIPTION
initial instructions in a step are feeded to the step with a vector of
bash lines instead of a script path.

This will allow the creation of HPC specific helper functions to
abstract the setup.