### PR TITLE
Archive old step log files on rerun

### DIFF
--- a/inst/templates/workflow/SWF/controller.sh
+++ b/inst/templates/workflow/SWF/controller.sh
@@ -26,6 +26,9 @@ make_env_cur_vars "$SWF_CUR"
 # Run the next sbatch job
 if [[ -f "$SWF__JOB_SCRIPT" ]]
 then
+    # Archive old log files for this step before submitting
+    archive_old_logs "${SWF_NAME}_step${SWF_CUR}" "$SLURM_JOB_ID" "$SWF_LOG_DIR"
+
     sbatch --dependency=afterany:"$SLURM_JOB_ID" \
            --output="$SWF__STEPS_OUT" \
            --job-name="${SWF_NAME}_step${SWF_CUR}" \

--- a/inst/templates/workflow/SWF/lib.sh
+++ b/inst/templates/workflow/SWF/lib.sh
@@ -25,6 +25,36 @@ function make_env_cur_vars {
   export SWF__INSTRUCTIONS_SCRIPT="$SWF__CUR_DIR/instructions.sh"
 }
 
+# Archive old log files for a step before resubmitting it.
+# Moves .out files with a job ID lower than the current one to log/archive/.
+# Arguments:
+#   $1 - step name (e.g., "wf_name_step1")
+#   $2 - current SLURM job ID (files with lower IDs are considered old)
+#   $3 - log directory path
+function archive_old_logs {
+  local step_name="$1"
+  local current_jobid="$2"
+  local log_dir="$3"
+  local archive_dir="$log_dir/archive"
+
+  for f in "$log_dir"/${step_name}_*.out; do
+    [ -f "$f" ] || continue
+
+    local basename
+    basename=$(basename "$f")
+    # Remove the step_name_ prefix and .out suffix to get JOBID_TASKID
+    local remainder="${basename#${step_name}_}"
+    remainder="${remainder%.out}"
+    # Extract the job ID (part before the first _)
+    local file_jobid="${remainder%%_*}"
+
+    if [[ "$file_jobid" =~ ^[0-9]+$ ]] && [ "$file_jobid" -lt "$current_jobid" ]; then
+      mkdir -p "$archive_dir"
+      mv "$f" "$archive_dir/"
+    fi
+  done
+}
+
 # convert CRLF endings to LF - `|| echo ""` prevents error when none is found
 function fix_crlf_files {
   local CRLF_FILES=$(find "$1" -type f | xargs file -F "::" | grep CRLF || echo "")


### PR DESCRIPTION
## Summary
- Adds an `archive_old_logs` bash function to `lib.sh` that moves `.out` files with a SLURM job ID lower than the current one to `log/archive/`
- Calls `archive_old_logs` from `controller.sh` before submitting each step, so that only logs from the current run remain in `log/`
- The `archive/` subdirectory is created on-demand only when old files are found

## How it works
Step log files follow the pattern `<wf_name>_step<N>_<jobid>_<taskid>.out`. Before submitting a step, the controller extracts the job ID from each matching file and compares it to its own `SLURM_JOB_ID`. Since SLURM job IDs are monotonically increasing, any existing step logs will have a lower ID and are moved to `log/archive/`.

After a rerun, the log directory looks like:
```
log/
├── archive/
│   ├── hpc_smoke_step1_36981635_4294967294.out
│   └── hpc_smoke_step2_36981637_4294967294.out
├── hpc_smoke_controller.out
├── hpc_smoke_step1_36981789_4294967294.out
└── hpc_smoke_step2_36981791_4294967294.out
```

Closes #31

## Test plan
- [ ] Create a workflow, run it, then rerun a step and verify old logs are moved to `log/archive/`
- [ ] Verify first run (no existing logs) works without errors
- [ ] Verify array jobs with multiple task IDs are all archived correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)